### PR TITLE
fix rule: github.com

### DIFF
--- a/src/rules_v2.js
+++ b/src/rules_v2.js
@@ -88,7 +88,7 @@ const RULES_MAP = {
   },
   "github.com": {
     autoScan: `false`,
-    selector: `h1, h2, h3, h4, h5, h6, .markdown-body li, p, dd, blockquote, figcaption, label, legend`,
+    selector: `h1, h2, h3, h4, h5, h6, .markdown-body li, p, dd, blockquote, figcaption, label, legend, .user-profile-bio>div, [data-testid="results-list"] .search-match`,
   },
   "*.notion.site": {
     ignoreSelector: ".notion-inline-code-container",


### PR DESCRIPTION
github.com:
- 支持 profile 翻译

<img width="2041" height="1203" alt="image" src="https://github.com/user-attachments/assets/f39c8d50-a727-4e6b-9bcd-46e5568eee96" />


- 支持 repository search results 中的仓库名、仓库描述翻译

<img width="1621" height="999" alt="image" src="https://github.com/user-attachments/assets/34834732-7ee3-41b7-8cec-963ac78d3270" />