### PR TITLE
fix rule: github.com

### DIFF
--- a/src/rules_v2.js
+++ b/src/rules_v2.js
@@ -88,7 +88,7 @@ const RULES_MAP = {
   },
   "github.com": {
     autoScan: `false`,
-    selector: `h1, h2, h3, h4, h5, h6, .markdown-body li, p, dd, blockquote, figcaption, label, legend, .user-profile-bio>div, [data-testid="results-list"] .search-match`,
+    selector: `h1, h2, h3, h4, h5, h6, .markdown-body li, p, dd, blockquote, figcaption, label, legend, .user-profile-bio>div, [data-testid="results-list"] .search-match`, .Subhead-description, [class^="prc-SelectPanel-Subtitle-"], [class^="prc-ActionList-ItemLabel-"], [role="dialog"] .overflow-auto
   },
   "*.notion.site": {
     ignoreSelector: ".notion-inline-code-container",


### PR DESCRIPTION
完善 Github 仓库设置界面翻译

#### `.Subhead-description`
<details>
	<summary><strong>preview</strong></summary>
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/ace4d696-0480-4fab-a2b0-c09df3159495" />
</details>

#### `[class^="prc-SelectPanel-Subtitle-"]`
<details>
	<summary><strong>preview</strong></summary>
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/dccd805a-d987-458c-9ad9-a0d1c29da096" />
</details>

#### `[class^="prc-ActionList-ItemLabel-"]`
<details>
	<summary><strong>preview</strong></summary>
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/9a920c91-4d0b-4512-bf23-840c9665c06e" />
</details>

#### `[role="dialog"] .overflow-auto`
<details>
	<summary><strong>preview</strong></summary>
<img width="1000" height="250" alt="image" src="https://github.com/user-attachments/assets/c83cb84f-fc93-4be9-9e92-b40a40985155" />
</details>
