### PR TITLE
fix rule: github.com

### DIFF
--- a/src/rules_v2.js
+++ b/src/rules_v2.js
@@ -89,6 +89,7 @@ const RULES_MAP = {
   "github.com": {
     autoScan: `false`,
     selector: `h1, h2, h3, h4, h5, h6, .markdown-body li, p, dd, blockquote, figcaption, label, legend, .user-profile-bio>div, [data-testid="results-list"] .search-match, .Subhead-description, [class^="prc-SelectPanel-Subtitle-"], [class^="prc-ActionList-ItemLabel-"], [role="dialog"] .overflow-auto`,
+    ignoreSelector: `p.pinned-item-desc+p`,
   },
   "*.notion.site": {
     ignoreSelector: ".notion-inline-code-container",


### PR DESCRIPTION
忽略置顶仓库描述下面的文字翻译（编程语言、star数，fork数）

<img width="2080" height="936" alt="image" src="https://github.com/user-attachments/assets/62be9bfd-8651-4eee-a831-703060e1af61" />