### PR TITLE
Add rules: meta.discourse.org, discussion.fedoraproject.org

### DIFF
--- a/src/rules_v2.js
+++ b/src/rules_v2.js
@@ -107,6 +107,42 @@ const RULES_MAP = {
   }
 }, 5000);`,
   },
+  "meta.discourse.org": {
+    injectJs: `document.addEventListener('selectionchange', (e) => {
+  const selection = window.getSelection();
+  if (selection && selection.anchorNode) {
+      const container = selection.anchorNode.parentElement;
+      if (container?.closest('.cooked')) {
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+      }
+  }
+}, true);
+
+document.addEventListener('mouseup', (e) => {
+  if (e.target.closest('.cooked')) {
+      e.stopPropagation();
+  }
+}, true);`,
+  },
+  "discussion.fedoraproject.org": {
+    injectJs: `document.addEventListener('selectionchange', (e) => {
+  const selection = window.getSelection();
+  if (selection && selection.anchorNode) {
+      const container = selection.anchorNode.parentElement;
+      if (container?.closest('.cooked')) {
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+      }
+  }
+}, true);
+
+document.addEventListener('mouseup', (e) => {
+  if (e.target.closest('.cooked')) {
+      e.stopPropagation();
+  }
+}, true);`,
+  },
   "store.steampowered.com": {
     ignoreSelector: `+#footer, +svg, +.bb_img_ctn, +#game_area_legal`,
   },


### PR DESCRIPTION
关联: [[Bug]鼠标选取译文时，译文自动消失](https://github.com/fishjar/kiss-translator/issues/422)
解决 Discourse 类论坛选中正文`.cooked`区域文字时，与 Discourse 监听事件冲突导致页面刷新