### PR TITLE
fix rule: github.com

### DIFF
--- a/src/rules_v2.js
+++ b/src/rules_v2.js
@@ -88,8 +88,8 @@ const RULES_MAP = {
   },
   "github.com": {
     autoScan: `false`,
-    selector: `h1, h2, h3, h4, h5, h6, .markdown-body li, p, dd, blockquote, figcaption, label, legend, .user-profile-bio>div, [data-testid="results-list"] .search-match, .Subhead-description, [class^="prc-SelectPanel-Subtitle-"], [class^="prc-ActionList-ItemLabel-"], [role="dialog"] .overflow-auto`,
-    ignoreSelector: `p.pinned-item-desc+p`,
+    selector: `h1, h2, h3, h4, h5, h6, .markdown-body li, p, dd, blockquote, figcaption, label, legend, .user-profile-bio>div, [data-testid="results-list"] .search-match, .Subhead-description, [class^="prc-SelectPanel-Subtitle-"], [class^="prc-ActionList-ItemLabel-"], [role="dialog"] .overflow-auto, .h4, .repos-list-description, .discussion-title, [class*="PinnedIssue-module__Link"] span, .js-wiki-sidebar-page-container :is(.Truncate-text, .Link--primary)`,
+    ignoreSelector: `button, p.pinned-item-desc+p`,
   },
   "*.notion.site": {
     ignoreSelector: ".notion-inline-code-container",


### PR DESCRIPTION
完善 Github 各界面翻译

### ignoreSelector
#### `button`：忽略按钮

### selector
#### `.h4`：Pull Request，GitHub Actions 界面
<details>
	<summary><strong>效果</strong></summary>
<img width="1000 height="670" alt="image" src="https://github.com/user-attachments/assets/ea6a8bad-41f8-4ca6-a457-6b5b13c5a7a4" />
<br><br>
<img width="1000" height="660" alt="image" src="https://github.com/user-attachments/assets/52cd0ab8-30d7-43c2-bb61-a25eda55ab26" />
</details>

#### `.repos-list-description`：组织仓库列表描述
<details>
	<summary><strong>效果</strong></summary>
<img width="1000" height="550" alt="image" src="https://github.com/user-attachments/assets/b5bc2935-589d-48a8-af0f-36cbb683dcba" />
</details>

#### `.discussion-title`：置顶 Discussions
<details>
	<summary><strong>效果</strong></summary>
<img width="1000" height="440" alt="image" src="https://github.com/user-attachments/assets/0949ff1b-507a-4a35-948b-eaf35d81d467" />
</details>

#### `[class*="PinnedIssue-module__Link"] span`：置顶 Issues
<details>
	<summary><strong>效果</strong></summary>
<img width="1000" height="350" alt="image" src="https://github.com/user-attachments/assets/6f00dde8-33da-4750-a719-8b2db6e43f44" />
</details>

#### `.js-wiki-sidebar-page-container :is(.Truncate-text, .Link--primary)`：Wiki 侧栏
<details>
	<summary><strong>效果</strong></summary>
<img width="1000" height="470" alt="image" src="https://github.com/user-attachments/assets/09896c06-082a-4594-9ece-930a461faf20" />
</details>