### PR TITLE
fix rule: old.reddit.com

### DIFF
--- a/src/rules_v2.js
+++ b/src/rules_v2.js
@@ -148,7 +148,7 @@ document.addEventListener('mouseup', (e) => {
   },
   "old.reddit.com": {
     selector: `.usertext`,
-    ignoreSelector: `.tabmenu, #sr-header-area, .tagline, .flat-list, .author`,
+    ignoreSelector: `.tabmenu, #sr-header-area, .tagline, .flat-list, .author, code`,
   },
   "/show_bug.cgi": {
     selector: `#field-value-short_desc, .comment-text`,


### PR DESCRIPTION
not translate element `code` that usually occurs inside `pre` for rendering codeblock