### PR TITLE
fix(rules): 修复 search.brave.com/ask 页面翻译导致页面卡死的问题

### DIFF
--- a/src/rules_v2.js
+++ b/src/rules_v2.js
@@ -156,6 +156,10 @@ document.addEventListener('mouseup', (e) => {
   "liveuamap.com": {
     rootsSelector: `.title`,
   },
+  "search.brave.com/ask": {
+    autoScan: `false`,
+    hasRichText: `false`,
+  },
 };
 
 const rules = Object.entries(RULES_MAP).map(([pattern, rule]) => ({

--- a/src/rules_v2.js
+++ b/src/rules_v2.js
@@ -157,8 +157,7 @@ document.addEventListener('mouseup', (e) => {
     rootsSelector: `.title`,
   },
   "search.brave.com/ask": {
-    autoScan: `false`,
-    hasRichText: `false`,
+    ignoreSelector: `#tap-input-field, .tap-input-field, .tap-input-field-wrapper, .ask-center-footer`,
   },
 };
 

--- a/src/rules_v2.js
+++ b/src/rules_v2.js
@@ -157,7 +157,7 @@ document.addEventListener('mouseup', (e) => {
     rootsSelector: `.title`,
   },
   "search.brave.com/ask": {
-    ignoreSelector: `#tap-input-field, .tap-input-field, .tap-input-field-wrapper, .ask-center-footer`,
+    ignoreSelector: `.ask-left, .ask-center-footer, #tap-input-field`,
   },
 };
 


### PR DESCRIPTION
开启自动扫描时，kiss 会扫描左侧历史记录侧边栏（`.ask-left`）的动态节点，干扰 Svelte 组件状态，导致底部输入框消失、页面无法滚动，只能刷新恢复。

通过 `ignoreSelector` 排除左侧栏及底部输入区域，保留对主体 AI 回答内容的正常翻译。

```js
"search.brave.com/ask": {
  ignoreSelector: `.ask-left, .ask-center-footer, #tap-input-field`,
},
```